### PR TITLE
Better steps - introducing default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pipeline.step to_s: 'This is the same as above' do |step, arg|
 end
 ```
 
-You can also define inline steps, meaning the block will be executed
+You can also define inline steps, meaning the block will be executed.
 
 ### Execution
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ pipeline.step to_s: 'This is the same as above' do |step, arg|
 end
 ```
 
-You can also define inline steps, meaning the block will be executed.
+You can also define inline steps, meaning the block will be executed. When you do not provide a :to_s option, type
+will be used as :to_s option per default. When no type was given for an inline block the type of the inline block 
+will be set to :inline. 
 
 ### Execution
 
@@ -104,6 +106,13 @@ NxtPipeline::Pipeline.execute('initial argument') do |p|
     arg.upcase
   end
 end
+``` 
+
+You can query the steps of your pipeline simply by calling `pipeline.steps`. A NxtPipeline::Step will provide you with 
+an interface it's type, options, status (:success, :skipped, :failed), result, error and the index in the pipeline.
+
+```
+pipeline.steps.first 
 ``` 
 
 ### Error callbacks

--- a/lib/nxt_pipeline.rb
+++ b/lib/nxt_pipeline.rb
@@ -1,4 +1,5 @@
 require 'nxt_pipeline/version'
+require 'nxt_pipeline/logger'
 require 'nxt_pipeline/pipeline'
 require 'nxt_pipeline/step'
 require 'nxt_pipeline/error_callback'

--- a/lib/nxt_pipeline.rb
+++ b/lib/nxt_pipeline.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'nxt_pipeline/version'
 require 'nxt_pipeline/logger'
 require 'nxt_pipeline/pipeline'

--- a/lib/nxt_pipeline/logger.rb
+++ b/lib/nxt_pipeline/logger.rb
@@ -1,0 +1,13 @@
+module NxtPipeline
+  class Logger
+    def initialize
+      @log = []
+    end
+
+    attr_accessor :log
+
+    def call(step)
+      log << { step.to_s => step.status }
+    end
+  end
+end

--- a/lib/nxt_pipeline/logger.rb
+++ b/lib/nxt_pipeline/logger.rb
@@ -1,13 +1,13 @@
 module NxtPipeline
   class Logger
     def initialize
-      @log = []
+      @log = {}
     end
 
     attr_accessor :log
 
     def call(step)
-      log << { step.to_s => step.status }
+      log[step.to_s] = step.status
     end
   end
 end

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -59,19 +59,6 @@ module NxtPipeline
       steps << Step.new(type, constructor, **opts)
     end
 
-    # def step(type = nil, **opts, &block)
-    #   if block_given?
-    #     # When block is given, the block is the constructor
-    #     # type becomes :to_s for inline constructors
-    #     # if no type was given call it :inline
-    #     type ||= :inline
-    #     opts.reverse_merge!(to_s: type)
-    #   end
-    #
-    #   constructor = resolve_constructor(type, &block)
-    #   steps << Step.new(type, constructor, **opts)
-    # end
-
     def execute(arg, &block)
       reset
 
@@ -105,16 +92,6 @@ module NxtPipeline
 
     def after_execute(&callback)
       self.after_execute_callback = callback
-    end
-
-    def resolve_constructor(type, &block)
-      return block if block_given?
-
-      if type
-        registry.fetch(type) { raise KeyError, "No step :#{type} registered" }
-      else
-        default_constructor || (raise StandardError, 'No default step registered')
-      end
     end
 
     private

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -42,28 +42,6 @@ module NxtPipeline
       steps << Step.new(type, constructor, **opts)
     end
 
-    # def step(type = nil, **opts, &block)
-    #   if block_given?
-    #     s = inline_step(type = :inline, block, **opts)
-    #     return steps << s
-    #   end
-    #
-    #   constructor = if type
-    #     registry.fetch(type) { raise KeyError, "No step :#{type} registered" }
-    #   else
-    #     type = default_constructor_name
-    #     default_constructor || (raise StandardError, 'No default step registered')
-    #   end
-    #
-    #   s = Step.new(type, constructor, **opts)
-    #   steps << s
-    # end
-
-    # def inline_step(type = :inline, constructor, **opts)
-    #   opts.reverse_merge!(to_s: type)
-    #   Step.new(type, constructor, **opts)
-    # end
-
     def execute(arg, &block)
       reset
 

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -42,7 +42,8 @@ module NxtPipeline
 
     def step(type = nil, **opts, &block)
       constructor = if block_given?
-        # make first argument the to_s of step if given
+        # make type the :to_s of inline steps
+        # fall back to :inline if no type is given
         type ||= :inline
         opts.reverse_merge!(to_s: type)
         block
@@ -50,6 +51,7 @@ module NxtPipeline
         if type
           registry.fetch(type) { raise KeyError, "No step :#{type} registered" }
         else
+          type = default_constructor_name
           default_constructor || (raise StandardError, 'No default step registered')
         end
       end

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -12,6 +12,7 @@ module NxtPipeline
       @current_arg = nil
       @default_constructor_name = nil
       @registry = {}
+
       configure(&block) if block_given?
     end
 
@@ -88,7 +89,12 @@ module NxtPipeline
     private
 
     attr_reader :error_callbacks, :registry
-    attr_accessor :steps, :current_step, :current_arg, :default_constructor_name, :before_execute_callback, :after_execute_callback
+    attr_accessor :steps,
+                  :current_step,
+                  :current_arg,
+                  :default_constructor_name,
+                  :before_execute_callback,
+                  :after_execute_callback
 
     def default_constructor
       return unless default_constructor_name

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -16,6 +16,8 @@ module NxtPipeline
       configure(&block) if block_given?
     end
 
+    alias_method :configure, :tap
+
     attr_accessor :logger
 
     # register steps with name and block
@@ -84,10 +86,6 @@ module NxtPipeline
 
     def after_execute(&callback)
       self.after_execute_callback = callback
-    end
-
-    def configure(&block)
-      self.tap(&block)
     end
 
     def resolve_constructor(type, &block)

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -26,7 +26,16 @@ module NxtPipeline
       registry[name] = constructor
 
       return unless opts.fetch(:default, false)
-      default_constructor_name ? (raise ArgumentError, 'Default step already defined') : self.default_constructor_name = name
+      set_default_constructor(name)
+    end
+
+    def set_default_constructor(name)
+      raise_duplicate_default_constructor if default_constructor_name.present?
+      self.default_constructor_name = name
+    end
+
+    def raise_duplicate_default_constructor
+      raise ArgumentError, 'Default step already defined'
     end
 
     def step(type = nil, **opts, &block)

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -31,7 +31,7 @@ module NxtPipeline
 
     def step(type = nil, **opts, &block)
       if block_given?
-        s = inline_step(inline_step(type = :inline, block, **opts))
+        s = inline_step(type = :inline, block, **opts)
         return steps << s
       end
 

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -41,17 +41,34 @@ module NxtPipeline
     end
 
     def step(type = nil, **opts, &block)
-      if block_given?
-        # When block is given, the block is the constructor
-        # type becomes :to_s for inline constructors
-        # if no type was given call it :inline
+      constructor = if block_given?
+        # make first argument the to_s of step if given
         type ||= :inline
         opts.reverse_merge!(to_s: type)
+        block
+      else
+        if type
+          registry.fetch(type) { raise KeyError, "No step :#{type} registered" }
+        else
+          default_constructor || (raise StandardError, 'No default step registered')
+        end
       end
 
-      constructor = resolve_constructor(type, &block)
       steps << Step.new(type, constructor, **opts)
     end
+
+    # def step(type = nil, **opts, &block)
+    #   if block_given?
+    #     # When block is given, the block is the constructor
+    #     # type becomes :to_s for inline constructors
+    #     # if no type was given call it :inline
+    #     type ||= :inline
+    #     opts.reverse_merge!(to_s: type)
+    #   end
+    #
+    #   constructor = resolve_constructor(type, &block)
+    #   steps << Step.new(type, constructor, **opts)
+    # end
 
     def execute(arg, &block)
       reset

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -59,7 +59,6 @@ module NxtPipeline
       after_execute_callback.call(self, result) if after_execute_callback.respond_to?(:call)
       result
     rescue StandardError => error
-
       log_step(current_step)
       callback = find_error_callback(error)
 

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -16,6 +16,7 @@ module NxtPipeline
 
     def execute(arg)
       self.result = constructor.call(self, arg)
+      set_status
       result
     rescue StandardError => e
       self.status = :failed
@@ -40,7 +41,7 @@ module NxtPipeline
     end
 
     def set_status
-      self.status = result.present? ? :success : :failed
+      self.status = result ? :success : :skipped
     end
   end
 end

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -1,9 +1,10 @@
 module NxtPipeline
   class Step
-    def initialize(type, constructor, **opts)
+    def initialize(type, constructor, index, **opts)
       define_attr_readers(opts)
 
       @type = type
+      @index = index
       @result = nil
       @opts = opts
       @status = nil
@@ -11,7 +12,7 @@ module NxtPipeline
       @error = nil
     end
 
-    attr_reader :type, :result, :status, :error, :opts
+    attr_reader :type, :result, :status, :error, :opts, :index
 
     def execute(arg)
       self.result = constructor.call(self, arg)
@@ -25,6 +26,10 @@ module NxtPipeline
 
     def to_s
       "#{opts.merge(type: type)}"
+    end
+
+    def type?(potential_type)
+      type.to_sym == potential_type.to_sym
     end
 
     private

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -41,7 +41,7 @@ module NxtPipeline
     end
 
     def set_status
-      self.status = result ? :success : :skipped
+      self.status = result.present? ? :success : :skipped
     end
   end
 end

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -11,7 +11,6 @@ module NxtPipeline
       @error = nil
     end
 
-    attr_accessor :constructor # TODO: Why is this an accessor? --> Should be private reader
     attr_reader :type, :result, :status, :error, :opts
 
     def execute(arg)
@@ -31,6 +30,7 @@ module NxtPipeline
     private
 
     attr_writer :result, :status, :error
+    attr_reader :constructor
 
     def define_attr_readers(opts)
       opts.each do |key, value|

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -1,25 +1,35 @@
 module NxtPipeline
   class Step
-    def initialize(constructor, **opts)
+    def initialize(type, constructor, **opts)
       define_attr_readers(opts)
+
+      @type = type
+      @result = nil
       @opts = opts
+      @status = nil
       @constructor = constructor
+      @error = nil
     end
 
-    attr_accessor :constructor
+    attr_accessor :constructor # TODO: Why is this an accessor? --> Should be private reader
+    attr_reader :type, :result, :status, :error, :opts
 
     def execute(arg)
-      constructor.call(self, arg)
-      # instance_exec(arg, &constructor)
+      self.result = constructor.call(self, arg)
+      result
+    rescue StandardError => e
+      self.status = :failed
+      self.error = e
+      raise
     end
 
     def to_s
-      "#{self.class} opts => #{opts}"
+      "#{opts.merge(type: type)}"
     end
 
     private
 
-    attr_reader :opts
+    attr_writer :result, :status, :error
 
     def define_attr_readers(opts)
       opts.each do |key, value|
@@ -27,6 +37,10 @@ module NxtPipeline
           value
         end
       end
+    end
+
+    def set_status
+      self.status = result.present? ? :success : :failed
     end
   end
 end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -369,9 +369,17 @@ RSpec.describe NxtPipeline do
       expect(subject.steps.find { |s| s.type?(:second_step) }.result).to eq('H_A_N_N_A')
     end
 
-    context 'when trying to define the type :inline' do
-      it 'raises an error' do
+    context 'when :to_s option was provided' do
+      before do
+        subject.configure do |p|
+          p.step to_s: 'What is my name' do |step, arg|
+            arg.prepend('My name is: ')
+          end
+        end
+      end
 
+      it 'does not use the type as :to_s option' do
+        expect(subject.steps.last.to_s).to eq('What is my name')
       end
     end
   end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -104,11 +104,11 @@ RSpec.describe NxtPipeline do
     it 'logs the steps' do
       subject.execute('hanna')
 
-      expect(subject.log).to eq(
-                                 "StepOne" => { status: :success },
-                                 "StepSkipped"=> { status: :skipped },
-                                 "StepWithArgumentError" => { status: :failed, reason: "ArgumentError: This is not a fish" }
-                             )
+      expect(subject.logger.log).to eq(
+        "StepOne" => :success,
+        "StepSkipped" => :skipped,
+        "StepWithArgumentError" => :failed
+      )
     end
   end
 

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -227,12 +227,12 @@ RSpec.describe NxtPipeline do
           end
 
           pipeline.after_execute do |pipeline, arg|
-            arg << " => status: #{pipeline.log.dig('anonymous_step', :status)}"
+            arg << " => status: #{pipeline.logger.log.dig('anonymous_step')}"
           end
         end
       end
 
-      it 'accesses the pipeline log' do
+      it 'accesses the loggers log' do
         expect(subject.execute('getsafe')).to eq('getsafe => status: success')
       end
     end
@@ -312,7 +312,7 @@ RSpec.describe NxtPipeline do
 
     it 'logs the steps' do
       subject.execute('hanna')
-      expect(subject.log).to eq("NxtPipeline::Step opts => {}" => { :status=>:success }, :second_step => { :status=>:success })
+      expect(subject.logger.log).to eq(:inline => :success, :second_step => :success)
     end
   end
 


### PR DESCRIPTION
@nsommer In order to get rid of the `:to_s` options and more flexible logging I made a few changes. You can now pass in a custom logger that needs to implement call. Thereby you can simply configure a logger once that logs based on the options that are passed in and naming every step becomes unnecessary. Call will be called with the step after it was successful, skipped or failed. One can now query the status of the step , simply by calling `step.status`. The step also remembers the error that caused it to fail `step.error`

Inline steps (those that come with their own constructor) are now named (:to_s) as :inline if no type was provided.

A few tests are missing and README needs update. But let me know what you think.