### PR TITLE
Dsl and constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Note that the `after_execute` callback will not be called, when an error is rais
 - Step orchestration (chainable steps)
 - Halting steps (probably already solved)
 - Removing / Mocking steps
+- Constructors should take arg as first and step as second arg
+- Constructors should accept :to_s option 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ class MyAwesomeClass
     end
     
     p.on_error MyCustomError do |step, arg, error|
-      # execute a pipeline simply by fetching it and calling execute on it as you would normally
+      # nesting pipelines also works
       pipeline(:error).execute(error)
     end
   end
@@ -213,6 +213,11 @@ class MyAwesomeClass
     p.step do |_, error|
       error # do something here
     end
+  end
+  
+  def call(arg)
+    # execute a pipeline simply by fetching it and calling execute on it as you would normally
+    pipeline(:execution).execute(arg)
   end
 end
 ```

--- a/lib/nxt_pipeline.rb
+++ b/lib/nxt_pipeline.rb
@@ -4,6 +4,7 @@ require 'nxt_pipeline/logger'
 require 'nxt_pipeline/pipeline'
 require 'nxt_pipeline/step'
 require 'nxt_pipeline/error_callback'
+require 'nxt_pipeline/dsl'
 
 module NxtPipeline
 end

--- a/lib/nxt_pipeline.rb
+++ b/lib/nxt_pipeline.rb
@@ -1,6 +1,7 @@
 require 'active_support/all'
 require 'nxt_pipeline/version'
 require 'nxt_pipeline/logger'
+require 'nxt_pipeline/constructor'
 require 'nxt_pipeline/pipeline'
 require 'nxt_pipeline/step'
 require 'nxt_pipeline/error_callback'

--- a/lib/nxt_pipeline/constructor.rb
+++ b/lib/nxt_pipeline/constructor.rb
@@ -1,0 +1,13 @@
+module NxtPipeline
+  class Constructor
+    def initialize(name, opts, block)
+      @name = name
+      @block = block
+      @opts = opts
+    end
+
+    attr_reader :block, :opts
+
+    delegate_missing_to :block
+  end
+end

--- a/lib/nxt_pipeline/constructor.rb
+++ b/lib/nxt_pipeline/constructor.rb
@@ -6,8 +6,14 @@ module NxtPipeline
       @opts = opts
     end
 
-    attr_reader :block, :opts
+    attr_reader :opts
 
-    delegate_missing_to :block
+    def call(*args, **opts)
+      block.call(*args, **opts)
+    end
+
+    private
+
+    attr_reader :block
   end
 end

--- a/lib/nxt_pipeline/constructor.rb
+++ b/lib/nxt_pipeline/constructor.rb
@@ -6,14 +6,8 @@ module NxtPipeline
       @opts = opts
     end
 
-    attr_reader :opts
+    attr_reader :opts, :block
 
-    def call(*args, **opts)
-      block.call(*args, **opts)
-    end
-
-    private
-
-    attr_reader :block
+    delegate :call, :arity, to: :block
   end
 end

--- a/lib/nxt_pipeline/dsl.rb
+++ b/lib/nxt_pipeline/dsl.rb
@@ -1,0 +1,44 @@
+module NxtPipeline
+  module Dsl
+    module ClassMethods
+      def pipeline(name = :default, &block)
+        name = name.to_sym
+
+        if block_given?
+          pipeline_registry.key?(name) && raise_already_registered_error(name)
+          pipeline_registry[name] = block
+        else
+          config = pipeline_registry.fetch(name) { raise KeyError, "No pipeline #{name} registered"}
+          NxtPipeline::Pipeline.new(&config)
+        end
+      end
+
+      def pipeline!(name, &block)
+        raise ArgumentError, "No block given!" unless block_given?
+        pipeline_registry[name] = block
+      end
+
+      private
+
+      def inherited(child)
+        child.instance_variable_set(:@pipeline_registry, pipeline_registry.clone)
+      end
+
+      def raise_already_registered_error(name)
+        raise KeyError, "Already registered a pipeline #{name}. Call pipeline! to overwrite already registered pipelines"
+      end
+
+      def pipeline_registry
+        @pipeline_registry ||= ActiveSupport::HashWithIndifferentAccess.new
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+
+      def pipeline(name = :default)
+        self.class.pipeline(name)
+      end
+    end
+  end
+end

--- a/lib/nxt_pipeline/dsl.rb
+++ b/lib/nxt_pipeline/dsl.rb
@@ -5,7 +5,7 @@ module NxtPipeline
         name = name.to_sym
 
         if block_given?
-          pipeline_registry.key?(name) && raise_already_registered_error(name)
+          raise_already_registered_error(name) if pipeline_registry.key?(name)
           pipeline_registry[name] = block
         else
           config = pipeline_registry.fetch(name) { raise KeyError, "No pipeline #{name} registered"}

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -25,7 +25,7 @@ module NxtPipeline
       name = name.to_sym
       raise StandardError, "Already registered step :#{name}" if registry[name]
 
-      registry[name] = constructor
+      registry[name] = Constructor.new(name, opts, constructor)
 
       return unless opts.fetch(:default, false)
       set_default_constructor(name)
@@ -48,7 +48,7 @@ module NxtPipeline
         # fall back to :inline if no type is given
         type ||= :inline
         opts.reverse_merge!(to_s: type)
-        block
+        Constructor.new(type, opts, block)
       else
         if type
           raise_reserved_type_inline_error if type == :inline

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -9,6 +9,9 @@ module NxtPipeline
       @opts = opts
       @status = nil
       @constructor = constructor
+      constructor_options = constructor.opts.with_indifferent_access
+      to_s = constructor_options[:to_s]
+      @to_s = to_s.respond_to?(:call) ? to_s.call(self) : to_s
       @error = nil
     end
 
@@ -32,7 +35,7 @@ module NxtPipeline
     end
 
     def to_s
-      "#{opts.merge(type: type)}"
+      @to_s || "#{opts.merge(type: type)}"
     end
 
     def type?(potential_type)

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -5,13 +5,12 @@ module NxtPipeline
 
       @type = type
       @index = index
-      @result = nil
       @opts = opts
-      @status = nil
       @constructor = constructor
-      constructor_options = constructor.opts.with_indifferent_access
-      to_s = constructor_options[:to_s]
-      @to_s = to_s.respond_to?(:call) ? to_s.call(self) : to_s
+      @to_s = to_s_from_constructor
+
+      @status = nil
+      @result = nil
       @error = nil
     end
 
@@ -46,6 +45,12 @@ module NxtPipeline
 
     attr_writer :result, :status, :error
     attr_reader :constructor
+
+    def to_s_from_constructor
+      constructor_options = constructor.opts.with_indifferent_access
+      to_s = constructor_options[:to_s]
+      to_s.respond_to?(:call) ? to_s.call(self) : to_s
+    end
 
     def if_guard
       opts.fetch(:if) { guard(true) }

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe NxtPipeline::Dsl do
+  let(:some_class) do
+    Class.new do
+      include NxtPipeline::Dsl
+
+      pipeline do |p|
+        p.step do |step, arg|
+          "Default: #{arg}"
+        end
+      end
+
+      pipeline :execution do |p|
+        p.step do |step, arg|
+          "Execution: #{arg}"
+        end
+      end
+
+      def call(pipeline_name, arg)
+        pipeline(pipeline_name).execute(arg)
+      end
+    end
+  end
+
+  subject do
+    some_class
+  end
+
+  describe '.pipeline' do
+    context 'when no name is given' do
+      it 'registers a default pipeline' do
+        expect(subject.pipeline.execute('Raphael Lütfi Nilsom')).to eq('Default: Raphael Lütfi Nilsom')
+        expect(subject.new.pipeline.execute('Raphael Lütfi Nilsom')).to eq('Default: Raphael Lütfi Nilsom')
+      end
+    end
+
+    context 'when a name was given' do
+      it 'registers a pipeline for that name' do
+        expect(subject.pipeline(:execution).execute('Raphael Lütfi Nilsom')).to eq('Execution: Raphael Lütfi Nilsom')
+        expect(subject.new.pipeline(:execution).execute('Raphael Lütfi Nilsom')).to eq('Execution: Raphael Lütfi Nilsom')
+      end
+    end
+
+    context 'when a pipeline was already registered with that name' do
+      it 'raises an error' do
+        expect {
+          subject.pipeline :execution do |p|
+            p.step do |step, arg|
+              "Oh oh: #{arg}"
+            end
+          end
+        }.to raise_error(KeyError, /Already registered a pipeline execution/)
+      end
+    end
+  end
+
+  describe '.pipeline!' do
+    subject do
+      Class.new(some_class) do
+        pipeline! :default do |p|
+          p.step do |step, arg|
+            "Hijacked: #{arg}"
+          end
+        end
+      end
+    end
+
+    it 'allows to overwrite already configured pipelines' do
+      expect(subject.pipeline(:default).execute('Raphael Lütfi Nilsom')).to eq('Hijacked: Raphael Lütfi Nilsom')
+      expect(subject.new.pipeline(:default).execute('Raphael Lütfi Nilsom')).to eq('Hijacked: Raphael Lütfi Nilsom')
+    end
+  end
+end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -96,21 +96,13 @@ RSpec.describe NxtPipeline do
   context 'when there is an error' do
     subject do
       NxtPipeline::Pipeline.new do |pipeline|
-        pipeline.constructor(:service) do |step, arg|
+        pipeline.constructor(:service, to_s: -> (step) { step.service_class.to_s }) do |step, arg|
           step.service_class.new(arg).call
         end
 
-        pipeline.step :service,
-                      service_class: StepOne,
-                      to_s: 'StepOne'
-
-        pipeline.step :service,
-                      service_class: StepSkipped,
-                      to_s: 'StepSkipped'
-
-        pipeline.step :service,
-                      service_class: StepWithArgumentError,
-                      to_s: 'StepWithArgumentError'
+        pipeline.step :service, service_class: StepOne
+        pipeline.step :service, service_class: StepSkipped, to_s: 'This step was skipped'
+        pipeline.step :service, service_class: StepWithArgumentError
 
         pipeline.on_error ArgumentError do |step, arg, error|
           "Step #{step} was called with #{arg} and failed with #{error.class}"
@@ -131,7 +123,7 @@ RSpec.describe NxtPipeline do
 
       expect(subject.logger.log).to eq(
         "StepOne" => :success,
-        "StepSkipped" => :skipped,
+        "This step was skipped" => :skipped,
         "StepWithArgumentError" => :failed
       )
     end


### PR DESCRIPTION
```ruby
class MyAwesomeClass
  include NxtPipeline::Dsl
  
  # register a pipeline with a name and a block
  pipeline :execution do |p|
    p.constructor(:adder, to_s: ->(step) { 'Adder' } do |step, arg|
      step.adder.call(arg)
    end

    pipeline.step :adder, adder: -> (arg) { arg + 1 }
    
    p.on_error MyCustomError do |step, arg, error|
      # nesting pipelines also works
      pipeline(:error).execute(error)
    end
  end
end
```