### PR TITLE
Revert keyword arguments

### DIFF
--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -1,7 +1,7 @@
 module NxtPipeline
   class Pipeline
-    def self.execute(**opts, &block)
-      new(&block).execute(**opts)
+    def self.execute(opts, &block)
+      new(&block).execute(opts)
     end
 
     def initialize(&block)
@@ -63,19 +63,19 @@ module NxtPipeline
       steps << Step.new(type, constructor, steps.count, **opts)
     end
 
-    def execute(**opts, &block)
+    def execute(arg, &block)
       reset
 
       configure(&block) if block_given?
-      before_execute_callback.call(self, opts) if before_execute_callback.respond_to?(:call)
+      before_execute_callback.call(self, arg) if before_execute_callback.respond_to?(:call)
 
-      result = steps.inject(opts) do |options, step|
-        execute_step(step, **options)
+      result = steps.inject(arg) do |argument, step|
+        execute_step(step, argument)
       rescue StandardError => error
         callback = find_error_callback(error)
         raise unless callback && callback.continue_after_error?
         handle_step_error(error)
-        options
+        argument
       end
 
       after_execute_callback.call(self, result) if after_execute_callback.respond_to?(:call)
@@ -122,12 +122,12 @@ module NxtPipeline
       @default_constructor ||= registry[default_constructor_name.to_sym]
     end
 
-    def execute_step(step, **opts)
+    def execute_step(step, arg)
       self.current_step = step
-      self.current_arg = opts
-      result = step.execute(**opts)
+      self.current_arg = arg
+      result = step.execute(arg)
       log_step(step)
-      result || opts
+      result || arg
     end
 
     def find_error_callback(error)

--- a/lib/nxt_pipeline/step.rb
+++ b/lib/nxt_pipeline/step.rb
@@ -20,13 +20,13 @@ module NxtPipeline
     alias_method :name=, :to_s=
     alias_method :name, :to_s
 
-    def execute(**opts)
-      guard_args = [opts, self]
+    def execute(arg)
+      guard_args = [arg, self]
       if_guard_args = guard_args.take(if_guard.arity)
       unless_guard_guard_args = guard_args.take(unless_guard.arity)
 
       if !unless_guard.call(*unless_guard_guard_args) && if_guard.call(*if_guard_args)
-        self.result = constructor.call(self, **opts)
+        self.result = constructor.call(self, arg)
       end
 
       set_status

--- a/spec/guard_clauses_spec.rb
+++ b/spec/guard_clauses_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe NxtPipeline::Pipeline do
   class StepOne
-    def initialize(word:)
-      @word = word
+    def initialize(opts)
+      @opts = opts
     end
 
     def call
-      @word.upcase
+      @opts.upcase
     end
 
     def to_s
@@ -15,8 +15,8 @@ RSpec.describe NxtPipeline::Pipeline do
 
   subject do
     NxtPipeline::Pipeline.new do |pipeline|
-      pipeline.constructor(:service, default: true) do |step, **opts|
-        step.service_class.new(**opts).call
+      pipeline.constructor(:service, default: true) do |step, arg|
+        step.service_class.new(arg).call
       end
     end
   end
@@ -25,7 +25,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes no arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: 'hanna') do |p|
+          subject.execute('hanna') do |p|
             p.step service_class: StepOne, if: -> { false }
           end
 
@@ -37,8 +37,8 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes a single arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: false) do |p|
-            p.step service_class: StepOne, if: -> (word:) { word }
+          subject.execute(false) do |p|
+            p.step service_class: StepOne, if: -> (arg) { arg }
           end
 
           expect(subject.logger.log.values.last).to eq(:skipped)
@@ -49,8 +49,8 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes two arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: false) do |p|
-            p.step service_class: StepOne, if: -> (opts, step) { step.is_a?(NxtPipeline::Step) && opts.fetch(:word) }
+          subject.execute(false) do |p|
+            p.step service_class: StepOne, if: -> (arg, step) { step.is_a?(NxtPipeline::Step) && arg }
           end
 
           expect(subject.logger.log.values.last).to eq(:skipped)
@@ -63,7 +63,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes no arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: 'hanna') do |p|
+          subject.execute('hanna') do |p|
             p.step service_class: StepOne, unless: -> { true }
           end
 
@@ -75,8 +75,8 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes a single arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: true) do |p|
-            p.step service_class: StepOne, unless: -> (word:) { word }
+          subject.execute(true) do |p|
+            p.step service_class: StepOne, unless: -> (arg) { arg }
           end
 
           expect(subject.logger.log.values.last).to eq(:skipped)
@@ -87,8 +87,8 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes two arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: true) do |p|
-            p.step service_class: StepOne, unless: -> (opts, step) { step.is_a?(NxtPipeline::Step) && opts.fetch(:word) }
+          subject.execute(true) do |p|
+            p.step service_class: StepOne, unless: -> (arg, step) { step.is_a?(NxtPipeline::Step) && arg }
           end
 
           expect(subject.logger.log.values.last).to eq(:skipped)


### PR DESCRIPTION
This reverts the move towards keyword arguments. Having a single argument actually comes with almost the same possibility as you can pass in a hash as the single argument. The cool thing about hashes is that you can merge back the result and thus steps can take different arguments throughout the workflow.

Not sure if keyword args are better. I would almost say no, since without you have the option of piping through a single argument and you still can use a hash if you need multiple or steps take different ones. 