### PR TITLE
Add step exection time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## nxt_pipeline 0.4.3 (October 20, 2020)
+
+Add new attribute readers on step object.
+
+After executing a step execution_finished_at execution_started_at and execution_duration
+will be set and can be accessed via attribute readers.
+
 ## nxt_pipeline 0.4.2 (October 12, 2020)
 
 * Fix bug when registering an error without passing arguments in which case the callback didn't get executed. More info: https://github.com/nxt-insurance/nxt_pipeline/issues/39

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_pipeline (0.4.2)
+    nxt_pipeline (0.4.3)
       activesupport
 
 GEM

--- a/lib/nxt_pipeline/version.rb
+++ b/lib/nxt_pipeline/version.rb
@@ -1,4 +1,4 @@
 module NxtPipeline
-  VERSION = "0.4.2".freeze
+  VERSION = "0.4.3".freeze
 end
 

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -128,8 +128,22 @@ RSpec.describe NxtPipeline::Pipeline do
 
     it 'sets the status of the steps' do
       subject.execute(arg: 'hanna')
-
       expect(subject.steps.map(&:status)).to eq(%i[success skipped failed])
+    end
+
+    it 'sets execution_started_at on all steps' do
+      subject.execute(arg: 'hanna')
+      expect(subject.steps.map(&:execution_started_at)).to all(be_present)
+    end
+
+    it 'sets execution_finished_at on all steps' do
+      subject.execute(arg: 'hanna')
+      expect(subject.steps.map(&:execution_finished_at)).to all(be_present)
+    end
+
+    it 'sets execution_duration on all steps' do
+      subject.execute(arg: 'hanna')
+      expect(subject.steps.map(&:execution_duration)).to all(be_present)
     end
 
     it 'remembers the error on the step' do


### PR DESCRIPTION
This PR add new attribute readers on step object.

After executing a step `execution_finished_at`, `execution_started_at` and `execution_duration`
will be set and can be accessed via attribute readers.