### PR TITLE
Call pipelines with :call instead of :execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ will be set to :inline.
 You can then execute the steps with:
 
 ```ruby
-pipeline.execute(arg: 'initial argument')
+pipeline.call(arg: 'initial argument')
 
 # Or run the steps directly using block syntax
 
-pipeline.execute(arg: 'initial argument') do |p|
+pipeline.call(arg: 'initial argument') do |p|
   p.step :service, service_class: MyServiceClass, to_s: 'First step'
   p.step :service, service_class: MyOtherServiceClass, to_s: 'Second step'
   p.step :job, job_class: MyJobClass # to_s is optional
@@ -106,7 +106,7 @@ end
 You can also directly execute a pipeline with:
 
 ```ruby
-NxtPipeline::Pipeline.execute(arg: 'initial argument') do |p|
+NxtPipeline::Pipeline.call(arg: 'initial argument') do |p|
   p.step do |_, arg:|
     { arg: arg.upcase }
   end
@@ -140,7 +140,7 @@ You can also define guard clauses that take a proc to prevent the execution of a
 When the guard takes an argument the step argument is yielded.
 
  ```ruby
- pipeline.execute(arg: 'initial argument') do |p|
+ pipeline.call(arg: 'initial argument') do |p|
    p.step :service, service_class: MyServiceClass, if: -> (arg:) { arg == 'initial argument' }
    p.step :service, service_class: MyOtherServiceClass, unless: -> { false }
  end
@@ -227,7 +227,7 @@ NxtPipeline::Pipeline.new do |p|
 end
 ```
 
-Note that the `after_execute` callback will not be called in case a step raises an error. 
+Note that the `after_execution` callback will not be called in case a step raises an error. 
 See the previous section (_Error callbacks_) for how to define callbacks that run in case of errors.
 
 ### Step resolvers

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 
 # same with block syntax
 # You can use this to split up execution from configuration
-pipeline.configure do |p|
- p.constructor(:call) do |step, arg:|
+pipeline.configure do
+ constructor(:call) do |step, arg:|
    result = step.caller.new(arg).call
    result && { arg: result }
  end

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -24,6 +24,14 @@ module NxtPipeline
 
     alias_method :configure, :tap
 
+    def configure(&block)
+      if block.arity == 1
+        tap(&block)
+      else
+        instance_exec(&block)
+      end
+    end
+
     attr_accessor :logger, :steps
 
     def constructor(name, **opts, &constructor)

--- a/lib/nxt_pipeline/pipeline.rb
+++ b/lib/nxt_pipeline/pipeline.rb
@@ -1,7 +1,12 @@
 module NxtPipeline
   class Pipeline
-    def self.execute(**opts, &block)
-      new(&block).execute(**opts)
+
+    class << self
+      def execute(**opts, &block)
+        new(&block).execute(**opts)
+      end
+
+      alias_method :call, :execute
     end
 
     def initialize(step_resolvers = default_step_resolvers, &block)

--- a/spec/callbacks_spec.rb
+++ b/spec/callbacks_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
   end
 
-  subject { pipeline.execute(change_set)[:acc] }
+  subject { pipeline.call(change_set)[:acc] }
 
   context 'execution' do
     let(:change_set) { { acc: [] } }

--- a/spec/guard_clauses_spec.rb
+++ b/spec/guard_clauses_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes no arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: 'hanna') do |p|
+          subject.call(word: 'hanna') do |p|
             p.step service_class: StepOne, if: -> { false }
           end
 
@@ -37,7 +37,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes a single arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: false) do |p|
+          subject.call(word: false) do |p|
             p.step service_class: StepOne, if: -> (word:) { word }
           end
 
@@ -49,7 +49,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes two arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: false) do |p|
+          subject.call(word: false) do |p|
             p.step service_class: StepOne, if: -> (opts, step) { step.is_a?(NxtPipeline::Step) && opts.fetch(:word) }
           end
 
@@ -63,7 +63,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes no arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: 'hanna') do |p|
+          subject.call(word: 'hanna') do |p|
             p.step service_class: StepOne, unless: -> { true }
           end
 
@@ -75,7 +75,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes a single arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: true) do |p|
+          subject.call(word: true) do |p|
             p.step service_class: StepOne, unless: -> (word:) { word }
           end
 
@@ -87,7 +87,7 @@ RSpec.describe NxtPipeline::Pipeline do
     context 'when the guard takes two arguments' do
       context 'and the guard claus applies' do
         it 'skips the step' do
-          subject.execute(word: true) do |p|
+          subject.call(word: true) do |p|
             p.step service_class: StepOne, unless: -> (opts, step) { step.is_a?(NxtPipeline::Step) && opts.fetch(:word) }
           end
 

--- a/spec/map_options_spec.rb
+++ b/spec/map_options_spec.rb
@@ -1,19 +1,28 @@
 RSpec.describe NxtPipeline::Pipeline do
-  context 'mapped options' do
+  describe '#map_options' do
     subject do
       NxtPipeline::Pipeline.new do |pipeline|
         pipeline.constructor(:proc, default: true) do |step, opts|
           step.proc.call(opts, step.mapped_options)
         end
 
-        pipeline.step :proc,
-                      proc: ->(change_set, options) { change_set.merge(options) },
-                      map_options: ->(change_set) { { additional: 'options' } }
+        pipeline.step proc: ->(change_set, options) { change_set.merge(options) }, map_options: ->(change_set) { { additional: 'options' } }
+        pipeline.step proc: ->(change_set, options) { change_set.merge(options) }, map_options: ->(change_set) { { more_additional: 'options' } }
+        pipeline.step do |_, changeset|
+          changeset.merge(curried: 'options') # inline steps can also be used to map options
+        end
+        pipeline.step proc: ->(change_set, options) { change_set.merge(options) }, map_options: ->(change_set) { { even_more_additional: 'options' } }
       end
     end
 
     it 'passes the mapped options to the constructor' do
-      expect(subject.call(original: 'options')).to eq(original: 'options', additional: 'options')
+      expect(subject.call(original: 'options')).to eq(
+       original: 'options',
+       additional: 'options',
+       more_additional: 'options',
+       curried: 'options',
+       even_more_additional: 'options'
+      )
     end
   end
 end

--- a/spec/map_options_spec.rb
+++ b/spec/map_options_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'passes the mapped options to the constructor' do
-      expect(subject.execute(original: 'options')).to eq(original: 'options', additional: 'options')
+      expect(subject.call(original: 'options')).to eq(original: 'options', additional: 'options')
     end
   end
 end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -376,8 +376,8 @@ RSpec.describe NxtPipeline::Pipeline do
 
     context 'when :to_s option was provided' do
       before do
-        subject.configure do |p|
-          p.step to_s: 'What is my name' do |step, arg:|
+        subject.configure do
+          step to_s: 'What is my name' do |step, arg:|
             { arg: arg.prepend('My name is: ') }
           end
         end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -222,18 +222,18 @@ RSpec.describe NxtPipeline::Pipeline do
 
     context 'when one handler was registered for multiple errors' do
       subject do
-        NxtPipeline::Pipeline.new do |pipeline|
-          pipeline.constructor(:error_test) do |step, error:|
+        NxtPipeline::Pipeline.new do
+          constructor(:error_test) do |step, error:|
             step.raisor.call(error)
           end
 
-          pipeline.step :error_test, raisor: -> (error) { raise error }
+          step :error_test, raisor: -> (error) { raise error }
 
-          pipeline.on_errors CustomError, OtherCustomError do |step, opts, error|
+          on_errors CustomError, OtherCustomError do |step, opts, error|
             'common callback fired'
           end
 
-          pipeline.on_error do |step, opts, error|
+          on_error do |step, opts, error|
             raise error
           end
         end
@@ -248,20 +248,20 @@ RSpec.describe NxtPipeline::Pipeline do
 
     context 'when a handler was configured not to halt the pipeline' do
       subject do
-        NxtPipeline::Pipeline.new do |pipeline|
-          pipeline.step :upcase do |_, word:|
+        NxtPipeline::Pipeline.new do
+          step :upcase do |_, word:|
             { word: word.upcase }
           end
 
-          pipeline.step :raisor do |_, word:|
+          step :raisor do |_, word:|
             raise ArgumentError
           end
 
-          pipeline.step :reverse do |_, word:|
+          step :reverse do |_, word:|
             { word: word.reverse }
           end
 
-          pipeline.on_error ArgumentError, halt_on_error: false do |step, opts, error|
+          on_error ArgumentError, halt_on_error: false do |step, opts, error|
             'Error handler which does not halt the pipeline'
           end
         end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -56,18 +56,18 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the steps' do
-      expect(subject.execute(word: 'hanna')).to eq(word: 'HANNA')
+      expect(subject.call(word: 'hanna')).to eq(word: 'HANNA')
     end
 
     it 'remembers the results of the steps on the steps' do
-      subject.execute(word: 'hanna')
+      subject.call(word: 'hanna')
 
       expect(subject.steps.first.result).to eq(word: 'HANNA')
       expect(subject.steps.second.result).to be_nil
     end
 
     it 'logs the steps' do
-      subject.execute(word: 'hanna')
+      subject.call(word: 'hanna')
 
       expect(subject.logger.log).to eq({"StepOne"=>:success, "StepSkipped"=>:skipped})
     end
@@ -113,11 +113,11 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the callback' do
-      expect(subject.execute(arg: 'hanna')).to eq('Step StepWithArgumentError was called with {:arg=>"HANNA"} and failed with ArgumentError')
+      expect(subject.call(arg: 'hanna')).to eq('Step StepWithArgumentError was called with {:arg=>"HANNA"} and failed with ArgumentError')
     end
 
     it 'logs the steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
 
       expect(subject.logger.log).to eq(
         "StepOne" => :success,
@@ -127,33 +127,33 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'sets the status of the steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       expect(subject.steps.map(&:status)).to eq(%i[success skipped failed])
     end
 
     it 'sets execution_started_at on all steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       expect(subject.steps.map(&:execution_started_at)).to all(be_present)
     end
 
     it 'sets execution_finished_at on all steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       expect(subject.steps.map(&:execution_finished_at)).to all(be_present)
     end
 
     it 'sets execution_duration on all steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       expect(subject.steps.map(&:execution_duration)).to all(be_present)
     end
 
     it 'remembers the error on the step' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
 
       expect(subject.steps.map(&:error)).to match([nil, nil, be_a(ArgumentError)])
     end
 
     it 'adds methods to the error' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       argument_error = subject.steps.map(&:error).last
       expect(argument_error.details.logger).to eq(subject.logger)
       expect(argument_error.details.step.to_s).to eq('StepWithArgumentError')
@@ -185,9 +185,9 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the first matching callback' do
-      expect(subject.execute(error: OtherCustomError)).to eq('other_custom_error callback fired')
-      expect(subject.execute(error: CustomError)).to eq('custom_error callback fired')
-      expect(subject.execute(error: ArgumentError)).to eq('all errors inheriting from standard error callback fired')
+      expect(subject.call(error: OtherCustomError)).to eq('other_custom_error callback fired')
+      expect(subject.call(error: CustomError)).to eq('custom_error callback fired')
+      expect(subject.call(error: ArgumentError)).to eq('all errors inheriting from standard error callback fired')
     end
 
     context 'when the more common handler was registered before the more specific handler' do
@@ -214,9 +214,9 @@ RSpec.describe NxtPipeline::Pipeline do
       end
 
       it 'executes the first matching callback' do
-        expect(subject.execute(error: OtherCustomError)).to eq('custom_error callback fired')
-        expect(subject.execute(error: CustomError)).to eq('custom_error callback fired')
-        expect { subject.execute(error: ArgumentError) }.to raise_error(ArgumentError)
+        expect(subject.call(error: OtherCustomError)).to eq('custom_error callback fired')
+        expect(subject.call(error: CustomError)).to eq('custom_error callback fired')
+        expect { subject.call(error: ArgumentError) }.to raise_error(ArgumentError)
       end
     end
 
@@ -240,9 +240,9 @@ RSpec.describe NxtPipeline::Pipeline do
       end
 
       it 'triggers the handler for all errors' do
-        expect(subject.execute(error: CustomError)).to eq('common callback fired')
-        expect(subject.execute(error: OtherCustomError)).to eq('common callback fired')
-        expect { subject.execute(error: ArgumentError) }.to raise_error(ArgumentError)
+        expect(subject.call(error: CustomError)).to eq('common callback fired')
+        expect(subject.call(error: OtherCustomError)).to eq('common callback fired')
+        expect { subject.call(error: ArgumentError) }.to raise_error(ArgumentError)
       end
     end
 
@@ -268,7 +268,7 @@ RSpec.describe NxtPipeline::Pipeline do
       end
 
       it 'executes both steps' do
-        expect(subject.execute(word: 'hello')).to eq(word: "OLLEH")
+        expect(subject.call(word: 'hello')).to eq(word: "OLLEH")
         expect(subject.logger.log).to eq(
           upcase: :success,
           raisor: :failed,
@@ -298,7 +298,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the steps' do
-      expect(subject.execute(arg: 'hanna')).to eq(arg: 'H_A_N_N_A_H_A_N_N_A')
+      expect(subject.call(arg: 'hanna')).to eq(arg: 'H_A_N_N_A_H_A_N_N_A')
     end
 
     it 'assigns the correct arguments' do
@@ -319,11 +319,11 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the steps' do
-      expect(subject.execute(arg: 'hanna')).to eq(arg: 'H_A_N_N_A')
+      expect(subject.call(arg: 'hanna')).to eq(arg: 'H_A_N_N_A')
     end
 
     it 'assigns the argument of the default constructor to the steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       expect(subject.steps.map(&:argument)).to all(eq(:proc))
     end
 
@@ -358,17 +358,17 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'executes the steps' do
-      expect(subject.execute(arg: 'hanna')).to eq(arg: 'H_A_N_N_A')
+      expect(subject.call(arg: 'hanna')).to eq(arg: 'H_A_N_N_A')
     end
 
     it 'logs the steps' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
       # fallback to type :inline for inline constructors without type
       expect(subject.logger.log).to eq(inline: :success, second_step: :success)
     end
 
     it 'logs the result for each step' do
-      subject.execute(arg: 'hanna')
+      subject.call(arg: 'hanna')
 
       expect(subject.steps.find { |s| s.argument == :inline }.result).to eq(arg: 'HANNA')
       expect(subject.steps.find { |s| s.argument == :second_step }.result).to eq(arg: 'H_A_N_N_A')
@@ -396,7 +396,7 @@ RSpec.describe NxtPipeline::Pipeline do
       end
 
       def call
-        pipeline.execute(arg: @string)
+        pipeline.call(arg: @string)
       end
 
       def pipeline
@@ -459,7 +459,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'logs the step with the customer logger' do
-      expect(subject.execute(number: 5)).to eq(number: 37)
+      expect(subject.call(number: 5)).to eq(number: 37)
       expect(subject.logger.log).to eq(%i[adder multiplier adder inline last_step])
     end
   end
@@ -476,7 +476,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'configures the pipeline' do
-      expect(subject.execute(arg: 'hanna')).to eq(arg: 'HANNA')
+      expect(subject.call(arg: 'hanna')).to eq(arg: 'HANNA')
     end
 
     it 'returns itself' do
@@ -488,9 +488,9 @@ RSpec.describe NxtPipeline::Pipeline do
     end
   end
 
-  describe '.execute' do
+  describe '.call' do
     subject do
-      NxtPipeline::Pipeline.execute(arg: 'hanna') do |pipeline|
+      NxtPipeline::Pipeline.call(arg: 'hanna') do |pipeline|
         pipeline.step do |_, arg:|
           arg.upcase
         end

--- a/spec/step_resolver_spec.rb
+++ b/spec/step_resolver_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe NxtPipeline::Pipeline do
     end
 
     it 'resolves the steps' do
-      expect(subject.execute(arg: 'hanna')).to eq(:HANNAHANNA)
+      expect(subject.call(arg: 'hanna')).to eq(:HANNAHANNA)
     end
   end
 end


### PR DESCRIPTION
I changed the pipeline interface to be :call instead of :execute as it will be possible to use them like service classes then.
Also allowed to use configuration blocks without yielding arguments as the dsl becomes prettier with that and often a reference is not needed. 